### PR TITLE
Fix flake8

### DIFF
--- a/jsonchecker/__init__.py
+++ b/jsonchecker/__init__.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 
 
 class DuplicateKeyFinder(object):
-
     """Duplicate Key Finder."""
 
     def __init__(self, quiet=False):

--- a/tests/jsonchecker_test.py
+++ b/tests/jsonchecker_test.py
@@ -9,7 +9,6 @@ import jsonchecker
 
 
 class DuplicateKeyFinderTest(unittest.TestCase):
-
     """Test DuplicateKeyFinder."""
 
     def path(self, path):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skipsdist = True
 envlist = flake8,unittest
 
 [testenv:flake8]
-commands = flake8
+commands = flake8 --ignore=D203 {posargs}
 deps = flake8
        flake8-docstrings
        flake8-coding

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps = flake8
        flake8-docstrings
        flake8-coding
        hacking
+       pep257>=0.7.0
 
 [testenv:unittest]
 commands = python setup.py test


### PR DESCRIPTION
Travis CI failed due to flake8:
```
flake8 runtests: commands[0] | flake8
./jsonchecker/__init__.py:13:1: D211 No blank lines allowed before class docstring
./tests/jsonchecker_test.py:11:1: D211 No blank lines allowed before class docstring
ERROR: InvocationError: '/home/travis/build/legoktm/jsonchecker/.tox/flake8/bin/flake8'
```
https://travis-ci.org/legoktm/jsonchecker/jobs/96940479#L119

```
./jsonchecker/__init__.py:13:1: D203 1 blank line required before class docstring
./tests/jsonchecker_test.py:11:1: D204 1 blank line required after class docstring
./tests/jsonchecker_test.py:11:1: D211 No blank lines allowed before class docstring
ERROR: InvocationError: '/home/travis/build/legoktm/jsonchecker/.tox/flake8/bin/flake8'
```
https://travis-ci.org/legoktm/jsonchecker/jobs/96944225#L116

Here's some fixes.