### PR TITLE
Return the exit code from run

### DIFF
--- a/jsonchecker/__init__.py
+++ b/jsonchecker/__init__.py
@@ -68,7 +68,7 @@ class DuplicateKeyFinder(object):
         """Check each directory in directories."""
         for directory in directories:
             self.check_directory(directory)
-        self.exit()
+        return self.exit()
 
     def exit(self):
         """print errors and exit."""


### PR DESCRIPTION
Otherwise it's always None and it will sys.exit(None) even if there are errors.