### PR TITLE
Add option to detect duplicate values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,4 +37,8 @@ of the full filename for each file scanned. Useful if you plan on checking a lar
 The script will exit with a status code of 1 if any duplicate keys are found,
 0 if none are.
 
+An optional ``--values`` argument can be passed to additionally check for duplicate values within each key. 
+The script will exitwith a status code of 1 if there are either duplicate keys or duplicate values are found, 
+0 if none are.
+
 Released into the public domain.

--- a/jsonchecker/__init__.py
+++ b/jsonchecker/__init__.py
@@ -10,8 +10,8 @@ import sys
 from collections import defaultdict
 
 
-class DuplicateKeyFinder(object):
-    """Duplicate Key Finder."""
+class DuplicateFinder(object):
+    """Duplicate Finder base class."""
 
     def __init__(self, quiet=False):
         """Constructor."""
@@ -22,16 +22,6 @@ class DuplicateKeyFinder(object):
     def mark_error(self, key, fname):
         """Record an error."""
         self.errors[fname].append(key)
-
-    def checker(self, seq, fname):
-        """Check routine."""
-        d = {}
-        for key, value in seq:
-            if key in d:
-                self.mark_error(key, fname)
-            else:
-                d[key] = value
-        return d
 
     def check_directory(self, directory):
         """Check one directory."""
@@ -70,16 +60,16 @@ class DuplicateKeyFinder(object):
             self.check_directory(directory)
         return self.exit()
 
-    def exit(self):
+    def exit_with_msg(self, msg):
         """print errors and exit."""
         if self.errors or self.invalids:
             if self.quiet:
                 print('')
             for fname in self.errors:
                 print('----')
-                print('Duplicate keys found in %s:' % fname)
-                for key in self.errors[fname]:
-                    print('* %s' % key)
+                print('Duplicate %s found in %s:' % (msg, fname))
+                for duplicate in self.errors[fname]:
+                    print('* %s' % duplicate)
             for fname, tb in self.invalids.items():
                 print('----')
                 print('Error while parsing %s:' % fname)
@@ -89,6 +79,71 @@ class DuplicateKeyFinder(object):
             if self.quiet:
                 print('')
             return 0
+
+
+class DuplicateKeyFinder(DuplicateFinder):
+    """Duplicate Key Finder."""
+
+    def checker(self, seq, fname):
+        """Check routine."""
+        d = {}
+        for key, value in seq:
+            if key in d:
+                self.mark_error(key, fname)
+            else:
+                d[key] = value
+        return d
+
+    def exit(self):
+        """print errors and exit."""
+        return self.exit_with_msg('keys')
+
+
+class DuplicateValueFinder(DuplicateFinder):
+    """Duplicate Value Finder."""
+
+    def hashable(self, v):
+        """Determine whether `v` can be hashed."""
+        try:
+            hash(v)
+        except TypeError:
+            return False
+        return True
+
+    def dupes_in_list(self, l):
+        """Return hashable duplicates from this list."""
+        seen = set()
+        seen_twice = set()
+        # Adds all elements it doesn't know yet to seen and
+        # adds all others to seen_twice
+        for x in l:
+            if self.hashable(x):
+                if x in seen:
+                    seen_twice.add(x)
+                else:
+                    seen.add(x)
+        return list(seen_twice)
+
+    def checker(self, seq, fname):
+        """Check routine."""
+        d = {}
+        for key, value in seq:
+            if isinstance(value, list):
+                dupes = self.dupes_in_list(value)
+                good = []
+                for x in value:
+                    if x in dupes and x not in self.errors[fname]:
+                        self.mark_error(x, fname)
+                    else:
+                        good.append(x)
+                d[key] = good
+            else:
+                d[key] = value
+        return d
+
+    def exit(self):
+        """print errors and exit."""
+        return self.exit_with_msg('values')
 
 
 def main():
@@ -101,7 +156,13 @@ def main():
     if not directories:
         print('No files or directories provided')
         sys.exit(1)
-    sys.exit(finder.run(directories))
+    ret = finder.run(directories)
+
+    if '--values' in sys.argv:
+        finder = DuplicateValueFinder(quiet='--quiet' in sys.argv)
+        ret = finder.run(directories) | ret
+
+    sys.exit(ret)
 
 if __name__ == '__main__':
     main()

--- a/tests/jsonchecker_test.py
+++ b/tests/jsonchecker_test.py
@@ -8,33 +8,62 @@ import unittest
 import jsonchecker
 
 
-class DuplicateKeyFinderTest(unittest.TestCase):
-    """Test DuplicateKeyFinder."""
+class DuplicateFinderTest(unittest.TestCase):
+    """DuplicateFinder base class."""
 
     def path(self, path):
         """Return test path."""
         return os.path.join(os.path.dirname(__file__), path)
 
-    def check_directory_helper(self, path):
+    def check_directory_helper(self, finder, path):
         """Check a directory."""
-        finder = jsonchecker.DuplicateKeyFinder()
         finder.check_directory(self.path(path))
         return finder
 
+    def expected_error_helper(self, finder, fname, expected):
+        """Assert expected error messages."""
+        self.assertIn(self.path(fname), finder.errors)
+        self.assertIn(expected, finder.errors[self.path(fname)])
+
+
+class DuplicateKeyFinderTest(DuplicateFinderTest):
+    """Test DuplicateKeyFinder."""
+
+    def setUp(self):
+        """Set up."""
+        self.finder = jsonchecker.DuplicateKeyFinder()
+
     def test_check_file(self):
         """Test there are no errors in all known good data files."""
-        finder = self.check_directory_helper(self.path('testdata/good'))
+        finder = self.check_directory_helper(self.finder, self.path('testdata/good'))
         self.assertEqual(finder.errors, {})
 
     def test_check_bad_file(self):
         """Verify errors are detected in all bad data files."""
-        finder = self.check_directory_helper(self.path('testdata/bad'))
-        self.assertIn(self.path('testdata/bad/bad.json'), finder.errors)
-        self.assertIn('key', finder.errors[self.path('testdata/bad/bad.json')])
-        self.assertIn(self.path('testdata/bad/bad2.json'), finder.errors)
-        self.assertIn('key3', finder.errors[self.path('testdata/bad/bad2.json')])
-        self.assertIn(self.path('testdata/bad/bad3.json'), finder.errors)
-        self.assertIn('key6', finder.errors[self.path('testdata/bad/bad3.json')])
+        finder = self.check_directory_helper(self.finder, self.path('testdata/bad'))
+        self.expected_error_helper(finder, 'testdata/bad/bad.json', 'key')
+        self.expected_error_helper(finder, 'testdata/bad/bad2.json', 'key3')
+        self.expected_error_helper(finder, 'testdata/bad/bad3.json', 'key6')
+        self.assertIn(self.path('testdata/bad/invalid.json'), finder.invalids)
+
+
+class DuplicateValueFinderTest(DuplicateFinderTest):
+    """Test DuplicateValueFinder."""
+
+    def setUp(self):
+        """Set up."""
+        self.finder = jsonchecker.DuplicateValueFinder()
+
+    def test_check_file(self):
+        """Test there are no errors in all known good data files."""
+        finder = self.check_directory_helper(self.finder, self.path('testdata/good'))
+        self.assertEqual(finder.errors, {})
+
+    def test_check_bad_file(self):
+        """Verify errors are detected in all bad data files."""
+        finder = self.check_directory_helper(self.finder, self.path('testdata/bad'))
+        self.expected_error_helper(finder, 'testdata/bad/bad-values.json', 'value3')
+        self.expected_error_helper(finder, 'testdata/bad/bad-values2.json', 'value11')
         self.assertIn(self.path('testdata/bad/invalid.json'), finder.invalids)
 
 

--- a/tests/testdata/bad/bad-values.json
+++ b/tests/testdata/bad/bad-values.json
@@ -1,0 +1,14 @@
+{
+    "key": [
+        "value"
+        ],
+    "key2": [
+        "value",
+        "value2"
+        ],
+    "key3": [
+        "value3",
+        "value3"
+        ]
+}
+

--- a/tests/testdata/bad/bad-values2.json
+++ b/tests/testdata/bad/bad-values2.json
@@ -1,0 +1,25 @@
+{
+  "key4": [
+    "value7"
+  ],
+  "key5": [
+    "value7",
+    "value8"
+  ],
+  "key6": [
+    {
+      "key7": [
+        "value9",
+        "value10"
+      ]
+    }
+  ],
+  "key8": [
+    {
+      "key9": [
+        "value11",
+        "value11"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Implements https://github.com/legoktm/jsonchecker/issues/5.
- Ignore *.pyc files generated when running tests. Updated with common things from https://github.com/github/gitignore
- Add a more complex JSON in bad3.json to test duplicate keys a bit more thoroughly.
- Add DuplicateValueFinder to find duplicate values.
  - Add tests for this with test data.
    - Also add non-duplicate values in good.json.
  - Refactor DuplicateKeyFinder and DuplicateValueFinder so they have a common base class DuplicateFinder to remove duplicate code.
  - Similarly for tests, refactor DuplicateKeyFinderTest and DuplicateValueFinderTest so they have a common base class DuplicateFinderTest. DuplicateKeyFinder to remove duplicate code.
    - Also add expected_error_helper to reduce duplicate test code.

Usage for checking duplicate keys is unchanged.

To also check for duplicate values as well as keys, use the `--values` option. Then if either of these checks fail, the exit code is 1.
