### PR TITLE
Travis CI: Test slower Python builds first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "pypy"
   - "pypy3"
+  - "pypy"
+  - "3.5"
+  - "3.4"
+  - "3.3"
+  - "3.2"
+  - "2.7"
 
 sudo: false
 # command to install dependencies


### PR DESCRIPTION
PyPy is often slower for Travis CI builds, run those first to make full use of Travis's five parallel build jobs so the build finishes sooner.

Also Python 3 is a bit slower than Py 2, and we're usually more interested in the latest Python 3 releases than earlier.